### PR TITLE
fix: handle guest users more safely and cleanly

### DIFF
--- a/js/src/forum/index.js
+++ b/js/src/forum/index.js
@@ -66,7 +66,7 @@ app.initializers.add('michaelbelgium-profile-views', function() {
             method: 'POST',
             url: app.forum.attribute('apiUrl') + '/profileview',
             body: { 
-                viewer: typeof app.session.user === 'undefined' ? null : app.session.user.id(),
+                viewer: app.session.user?.id() ?? null,
                 viewedUser: this.user.id()
             }
         });


### PR DESCRIPTION
After recent updates, `app.session.user` is now null, not undefined, when the user is a guest. This handles both cases and is a bit more concise.